### PR TITLE
Add code for making http requests and code for mock api

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_API_URL='http://localhost:5000/api'

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_API_URL='http://localhost:5000/api'

--- a/.env.staging
+++ b/.env.staging
@@ -1,0 +1,1 @@
+REACT_APP_API_URL='http://localhost:5000/api'

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ yarn-debug.log*
 yarn-error.log*
 package-lock.json
 
+# vscode
+.vscode

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 
 Runs eslint on all JS files under the src directory
 
+
+### `yarn run lint-fix`
+
+Runs eslint --fix on all JS files under the src directory
+
 ## Learn More
 
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 In the project directory, you can run:
 
-### `npm start`
+### `yarn start`
 
 Runs the app in the development mode.<br>
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
@@ -12,12 +12,12 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 The page will reload if you make edits.<br>
 You will also see any lint errors in the console.
 
-### `npm test`
+### `yarn test`
 
 Launches the test runner in the interactive watch mode.<br>
 See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
 
-### `npm run build`
+### `yarn run build`
 
 Builds the app for production to the `build` folder.<br>
 It correctly bundles React in production mode and optimizes the build for the best performance.
@@ -27,7 +27,7 @@ Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
 
-### `npm run eject`
+### `yarn run eject`
 
 **Note: this is a one-way operation. Once you `eject`, you can’t go back!**
 
@@ -36,6 +36,10 @@ If you aren’t satisfied with the build tool and configuration choices, you can
 Instead, it will copy all the configuration files and the transitive dependencies (Webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
 
 You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+
+### `yarn run lint`
+
+Runs eslint on all JS files under the src directory
 
 ## Learn More
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "axios": "^0.18.0",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-scripts": "2.1.3"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "lint": "eslint src/*.js",
+    "lint": "eslint src/*.js src/**/*.js",
+    "lint-fix": "eslint src/*.js src/**/*.js --fix",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/src/http/HttpClient.js
+++ b/src/http/HttpClient.js
@@ -1,0 +1,68 @@
+import axios from 'axios';
+
+export class HttpClient {
+  static async makeRequest(config) {
+    const response = await axios.request(config);
+
+    if (response.status === 500) {
+      throw new Error(response.statusText);
+    }
+
+    return JSON.parse(response.data);
+  }
+
+  static get(url, headers = {}) {
+    const config = {
+      url,
+      headers,
+      method: 'GET',
+      ...HttpClient.getDefaultAxiosConfig()
+    };
+
+    return this.makeRequest(config);
+  }
+
+  static post(url, body, headers = {}) {
+    const config = {
+      url,
+      headers,
+      method: 'POST',
+      data: JSON.stringify(body),
+      ...HttpClient.getDefaultAxiosConfig()
+    };
+
+    return this.makeRequest(config);
+  }
+
+  static put(url, body, headers = {}) {
+    const config = {
+      url,
+      headers,
+      method: 'PUT',
+      data: JSON.stringify(body),
+      ...HttpClient.getDefaultAxiosConfig()
+    };
+
+    return this.makeRequest(config);
+  }
+
+  static delete(url, headers = {}) {
+    const config = {
+      url,
+      headers,
+      method: 'DELETE',
+      ...HttpClient.getDefaultAxiosConfig()
+    };
+
+    return this.makeRequest(config);
+  }
+
+  static getDefaultAxiosConfig() {
+    const config = {
+      responseType: 'application/json',
+      baseURL: process.env.REACT_APP_API_URL
+    };
+
+    return config;
+  }
+}

--- a/src/mockServices/MockApiService.js
+++ b/src/mockServices/MockApiService.js
@@ -3,7 +3,7 @@
 // Note: disabling eslint unused var rule for this file
 // to match function signatures for both MockApiService and
 // ApiService class
-import { getMemberProfile } from './mockResponses';
+import { getMemberProfile } from './mockApiResponses';
 
 export class MockApiService {
   getMemberProfile(id) {

--- a/src/mockServices/MockApiService.js
+++ b/src/mockServices/MockApiService.js
@@ -1,0 +1,12 @@
+/* eslint no-unused-vars : 0 */
+
+// Note: disabling eslint unused var rule for this file
+// to match function signatures for both MockApiService and
+// ApiService class
+import { getMemberProfile } from './mockResponses';
+
+export class MockApiService {
+  getMemberProfile(id) {
+    return Promise.resolve(getMemberProfile);
+  }
+}

--- a/src/mockServices/mockApiResponses/getMemberProfile.js
+++ b/src/mockServices/mockApiResponses/getMemberProfile.js
@@ -1,0 +1,20 @@
+export const getMemberProfile = {
+    username: "GreenWithMV",
+    userAvatar: "https://projectunicorn.blob.core.windows.net/members/memberimage.png",
+    socialLinks: {
+        linkedin: "https://www.linkedin.com/in/roy-moran-a8b42b9b",
+        twitter: "https://twitter.com/roymoran_",
+        github: "https://github.com/roymoran",
+    },
+    timezone: "PST",
+    location: "Seattle, USA",
+    type: "Hobbyist",
+    primaryRole: "backend",
+    weeklyHoursAvailable: "10",
+    yearsExperience: "1",
+    tools: {
+        frontend: ["html", "css", "javascript", "typescript", "react"],
+        backend: ["nodejs", "postgresql", ""],
+        design: ["adobe illustrator"]
+    }
+}

--- a/src/mockServices/mockApiResponses/index.js
+++ b/src/mockServices/mockApiResponses/index.js
@@ -1,0 +1,1 @@
+export * from './getMemberProfile';

--- a/src/services/ApiService.js
+++ b/src/services/ApiService.js
@@ -1,0 +1,7 @@
+import { HttpClient } from '../http/HttpClient';
+
+export class ApiService {
+  getMemberProfile(id) {
+    return HttpClient.get(`/members/${id}`);
+  }
+}

--- a/src/services/ServiceResolver.js
+++ b/src/services/ServiceResolver.js
@@ -1,0 +1,12 @@
+import { ApiService } from './ApiService';
+import { MockApiService } from '../mockServices/MockApiService';
+
+export class ServiceResolver {
+  constructor() {
+    this.useMock = true;
+  }
+
+  ApiResolver() {
+    return this.useMock ? new MockApiService() : new ApiService();
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1245,6 +1245,14 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  integrity sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
+
 axobject-query@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.0.2.tgz#ea187abe5b9002b377f925d8bf7d1c561adf38f9"
@@ -3411,7 +3419,7 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
-follow-redirects@^1.0.0:
+follow-redirects@^1.0.0, follow-redirects@^1.3.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.6.1.tgz#514973c44b5757368bad8bddfe52f81f015c94cb"
   dependencies:


### PR DESCRIPTION
Add code for making api requests both mock and actual
- HttpClient.js contains methods that will handle all network requests for frontend
- ApiService.js contains  all methods for available api calls
- MockApiService.js contains methods same methods as ApiService.js but instead return a mocked response
- MockApiResponses directory contains all our mocked responses
- ServiceResolver.js contains logic that will decide which api to use based on value of `this.useMock` current default value is true
- add .env files to pick up correct api endpoint based on environment app is deployed to
- add .vscode to .gitignore 
- Add single method to MockApiService and ApiService `getMemberProfile`. Plus include single mock file for member profile.

Sample usage in react component for making api calls
```
async componentDidMount() {
  const api = new ServiceResolver().ApiResolver();
  const response = await api.getMemberProfile(1);
  console.log(response);
}
```

